### PR TITLE
Reorganize team and projects pages with modern design and proper year grouping

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -4,232 +4,269 @@ permalink: /about/
 layout: splash
 ---
 
-![Data Science Group Team]( {{ site.baseurl }}/assets/images/dsgteam25.jpeg )
-
-We are Data Science Group, IIT Roorkee. A student organizaton, part of the umbrella organization Software Development Section. We aim to work on innovative open source projects in the domain of Machine Learning, Deep Learning & Reinforcement Learning, bridging the gap between research and industry. In the process, we fullfil our mission of cultivating and evolving the technical community at IIT Roorkee by organizing lectures, workshops, hackathons spanning the field of Data Science and AI.
-
-## Our Team
-
-<div class="member-grid">
-
- <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y23/aayan.jpeg" width= 200 height= 200 alt="Aayan Yadav">
-    <h3><a href="{{ site.baseurl }}/members/aayanyadav">Aayan Yadav</a></h3>
-  </div>
- <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y22/aasthakhaitan.jpeg" width= 200 height= 200 alt="Aastha Khaitan">
-    <h3><a href="{{ site.baseurl }}/members/aasthakhaitan">Aastha Khaitan</a></h3>
-  </div>
-
- <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y23/parth.jpg" width= 200 height= 200 alt="Parth Badgujar">
-    <h3><a href="{{ site.baseurl }}/members/parthbadgujar">Parth Badgujar</a></h3>
-  </div>
-
- <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y22/vedumrajkar.jpeg" width= 200 height= 200 alt="Ved Umrajkar">
-    <h3><a href="{{ site.baseurl }}/members/vedumrajkar">Ved Umrajkar</a></h3>
-  </div>
-
- <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y23/shree.jpeg" width= 200 height= 200 alt="Shree Singhi">
-    <h3><a href="{{ site.baseurl }}/members/shreesinghi">Shree Singhi</a></h3>
-</div>
-
- <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y23/shorya.jpg" width= 200 height= 200 alt="Shorya Singhal">
-    <h3><a href="{{ site.baseurl }}/members/shoryasinghal">Shorya Singhal</a></h3>
-</div>
-
- <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y23/anupriya_image.jpg" width= 200 height= 200 alt="Anupriya Kumari">
-    <h3><a href="{{ site.baseurl }}/members/anupriyakkumari">Anupriya Kumari</a></h3>
-  </div>
-
- <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y23/Screenshot 2025-03-28 175712.png" width= 200 height= 200 alt="Barath Chandran">
-    <h3><a href="{{ site.baseurl }}/members/barathchandran">Barath Chandran</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y23/Agam_PFP.png" width= 200 height= 200 alt="Agam Pandey">
-    <h3><a href="{{ site.baseurl }}/members/agampandey">Agam Pandey</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y24/otterv.webp" width= 200 height= 200 alt="Atharv Mittal">
-    <h3><a href="{{ site.baseurl }}/members/atharvmittal">Atharv Mittal</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y24/cp.jpeg" width= 200 height= 200 alt="Cherish Puniani">
-    <h3><a href="{{ site.baseurl }}/members/cherishpuniani">Cherish Puniani</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y24/jheelmaheshwari.png" width= 200 height= 200 alt="Jheel Maheshwari">
-    <h3><a href="{{ site.baseurl }}/members/JheelMaheshwari">Jheel Maheshwari</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y24/ojasv.jpg" width= 200 height= 200  alt="Ojasva Nema">
-    <h3><a href="{{ site.baseurl }}/members/ojasvanema">Ojasva Nema</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y23/sukrit.JPG" width= 200 height= 200 alt="Sukrit Jindal">
-    <h3><a href="{{ site.baseurl }}/members/sukritjindal">Sukrit Jindal</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y23/swadesh.png" width= 200 height= 200 alt="Swadesh Swain">
-    <h3><a href="{{ site.baseurl }}/members/swadeshswain">Swadesh Swain</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y25/adityachauhan.jpg" alt="Aditya Chauhan">
-    <h3><a href="{{ site.baseurl }}/members/adityachauhan">Aditya Chauhan</a></h3>
-  </div>
-
-  <div class="member-card">
-
-    <img src="{{ site.baseurl }}/assets/images/members/y24/advika.jpeg" width="200" height="200" alt="Advika Sinha">
-    <h3><a href="{{ site.baseurl }}/members/advika">Advika Sinha</a></h3>
-
-  </div>
-
- <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y24/abhivansh.jpeg" width= 200 height= 200 alt="Abhivansh Gupta">
-    <h3><a href="{{ site.baseurl }}/members/abhivanshgupta">Abhivansh Gupta</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y24/kaustubh.jpg" alt="Kaustubh Sharma">
-    <h3><a href="{{ site.baseurl }}/members/kaustubhsharma">Kaustubh Sharma</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y24/amritanshu.png" alt="amritanshu">
-    <h3><a href="{{ site.baseurl }}/members/amritanshu">Amritanshu Tiwari</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y23/aakash.jpeg" alt="Aakash Kr Singh">
-    <h3><a href="{{ site.baseurl }}/members/aakashkrsingh">Aakash Kumar Singh</a></h3>
-  </div>
-
-  <!--EX MEMBER
-   <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y25/asutosh_PFP.jpg" alt="Asutosh Maharana">
-    <h3><a href="{{ site.baseurl }}/members/asutosh">Asutosh Maharana</a></h3>
-  </div> -->
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y25/gaurav.jpg" alt="Gaurav Kumar">
-    <h3><a href="{{ site.baseurl }}/members/gaurav">Gaurav Kumar</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y23/anantjain.png" alt="Anant Jain">
-    <h3><a href="{{ site.baseurl }}/members/anantjain">Anant Jain</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y24/tushar.jpeg" alt="Tushar">
-    <h3><a href="{{ site.baseurl }}/members/Tushar">Tushar</a></h3>
-  </div>
-  
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y25/akshat_tomar.jpg" width="200" height="200" alt="Akshat Tomar">
-    <h3><a href="{{ site.baseurl }}/members/akshat">Akshat Tomar</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y25/raj.jpg" width="200" height="200" alt="Raj Shekhar Singh">
-    <h3><a href="{{ site.baseurl }}/members/raj">Raj Shekhar Singh</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y25/shreyansh.jpg" width="200" height="200" alt="Shreyansh Modi">
-    <h3><a href="{{ site.baseurl }}/members/shreyansh">Shreyansh Modi</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y25/arnav.png" width="200" height="200" alt="Arnav Bendre">
-    <h3><a href="{{ site.baseurl }}/members/arnav">Arnav Bendre</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y25/srijan.jpg" width="200" height="200" alt="Srijan Tiwari">
-    <h3><a href="{{ site.baseurl }}/members/srijan">Srijan Tiwari</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y25/manjot.jpg" width="200" height="200" alt="Manjot Singh">
-    <h3><a href="{{ site.baseurl }}/members/manjot">Manjot Singh</a></h3>
-  </div>
-
-  <!-- EX MEMBER <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y25/arya.jpg" width="200" height="200" alt="Arya Talera">
-    <h3><a href="{{ site.baseurl }}/members/arya">Arya Talera</a></h3>
-  </div> -->
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y25/aarush.jpg" width="200" height="200" alt="Aarush Aggarwal">
-    <h3><a href="{{ site.baseurl }}/members/aarush">Aarush Aggarwal</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y25/laabhanvi.jpg" width="200" height="200" alt="Laabhanvi Jain">
-    <h3><a href="{{ site.baseurl }}/members/laabhanvi">Laabhanvi Jain</a></h3>
-  </div>
-
-  <div class="member-card">
-    <img src="{{ site.baseurl }}/assets/images/members/y24/sargam.jpg" alt="Sargam Goyal">
-    <h3><a href="{{ site.baseurl }}/members/SargamGoyal">Sargam Goyal</a></h3>
-  </div>
-
-</div>
-
 <style>
+.about-hero {
+  text-align: center;
+  padding: 4rem 20px;
+  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+  border-radius: 16px;
+  margin-bottom: 3rem;
+}
+
+.about-hero img {
+  width: 100%;
+  max-width: 800px;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+  margin-bottom: 2rem;
+}
+
+.about-hero p {
+  font-size: 1.15rem;
+  color: #4a5568;
+  max-width: 900px;
+  margin: 0 auto;
+  line-height: 1.8;
+}
+
+.year-section {
+  margin-bottom: 4rem;
+}
+
+.year-header {
+  font-size: 2rem;
+  color: #2c3e50;
+  border-bottom: 3px solid #007acc;
+  padding-bottom: 10px;
+  margin-bottom: 2rem;
+  display: inline-block;
+}
+
 .member-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   gap: 30px;
-  margin-top: 2rem;
 }
 
 .member-card {
-  background: #f2f2f2;
+  background: #ffffff;
   padding: 16px;
-  border-radius: 12px;
-  box-shadow: 0 4px 10px rgba(0,0,0,0.05);
+  border-radius: 16px;
+  box-shadow: 0 4px 15px rgba(0,0,0,0.06);
   text-align: center;
-  transition: transform 0.2s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  border: 1px solid #f1f3f5;
 }
 
 .member-card:hover {
-  transform: translateY(-5px);
+  transform: translateY(-8px);
+  box-shadow: 0 12px 25px rgba(0,0,0,0.1);
 }
 
 .member-card img {
-  width: 200px;
-  height: 200px;
-  object-fit: cover;   /* crops nicely instead of stretching */
-  border-radius: 10px;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 12px;
+  margin-bottom: 1rem;
 }
 
 .member-card h3 {
-  margin-top: 1rem;
-  font-size: 1.1rem;
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
 }
 
 .member-card a {
-  color: #007acc;
+  color: #2c3e50;
   text-decoration: none;
+  transition: color 0.2s ease;
 }
 
 .member-card a:hover {
-  text-decoration: underline;
+  color: #007acc;
 }
 </style>
+
+<div class="about-hero">
+  <img src="{{ site.baseurl }}/assets/images/dsgteam25.jpeg" alt="Data Science Group Team">
+  <p>We are Data Science Group, IIT Roorkee. A student organization, part of the umbrella organization Software Development Section. We aim to work on innovative open source projects in the domain of Machine Learning, Deep Learning & Reinforcement Learning, bridging the gap between research and industry. In the process, we fulfill our mission of cultivating and evolving the technical community at IIT Roorkee by organizing lectures, workshops, hackathons spanning the field of Data Science and AI.</p>
+</div>
+
+<div class="team-container">
+  <h1 style="text-align: center; font-size: 3rem; margin-bottom: 3rem;">Our Team</h1>
+
+  <!-- 4th Year (Y23) -->
+  <div class="year-section">
+    <h2 class="year-header">4th Year (Y23)</h2>
+    <div class="member-grid">
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y23/aakash.jpeg" alt="Aakash Kr Singh" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/aakashkrsingh">Aakash Kumar Singh</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y23/aayan.jpeg" alt="Aayan Yadav" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/aayanyadav">Aayan Yadav</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y23/Agam_PFP.png" alt="Agam Pandey" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/agampandey">Agam Pandey</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y23/anantjain.png" alt="Anant Jain" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/anantjain">Anant Jain</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y23/anupriya_image.jpg" alt="Anupriya Kumari" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/anupriyakkumari">Anupriya Kumari</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y23/Screenshot 2025-03-28 175712.png" alt="Barath Chandran" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/barathchandran">Barath Chandran</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y23/parth.jpg" alt="Parth Badgujar" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/parthbadgujar">Parth Badgujar</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y23/shorya.jpg" alt="Shorya Singhal" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/shoryasinghal">Shorya Singhal</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y23/shree.jpeg" alt="Shree Singhi" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/shreesinghi">Shree Singhi</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y23/sukrit.JPG" alt="Sukrit Jindal" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/sukritjindal">Sukrit Jindal</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y23/swadesh.png" alt="Swadesh Swain" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/swadeshswain">Swadesh Swain</a></h3>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3rd Year (Y24) -->
+  <div class="year-section">
+    <h2 class="year-header">3rd Year (Y24)</h2>
+    <div class="member-grid">
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y24/abhivansh.jpeg" alt="Abhivansh Gupta" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/abhivanshgupta">Abhivansh Gupta</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y24/advika.jpeg" alt="Advika Sinha" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/advika">Advika Sinha</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y24/amritanshu.png" alt="Amritanshu Tiwari" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/amritanshu">Amritanshu Tiwari</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y24/otterv.webp" alt="Atharv Mittal" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/atharvmittal">Atharv Mittal</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y24/cp.jpeg" alt="Cherish Puniani" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/cherishpuniani">Cherish Puniani</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y24/jheelmaheshwari.png" alt="Jheel Maheshwari" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/JheelMaheshwari">Jheel Maheshwari</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y24/kaustubh.jpg" alt="Kaustubh Sharma" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/kaustubhsharma">Kaustubh Sharma</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y24/ojasv.jpg" alt="Ojasva Nema" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/ojasvanema">Ojasva Nema</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y24/sargam.jpg" alt="Sargam Goyal" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/SargamGoyal">Sargam Goyal</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y24/tushar.jpeg" alt="Tushar" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/Tushar">Tushar</a></h3>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2nd Year (Y25) -->
+  <div class="year-section">
+    <h2 class="year-header">2nd Year (Y25)</h2>
+    <div class="member-grid">
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y25/aarush.jpg" alt="Aarush Aggarwal" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/aarush">Aarush Aggarwal</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y25/adityachauhan.jpg" alt="Aditya Chauhan" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/adityachauhan">Aditya Chauhan</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y25/akshat_tomar.jpg" alt="Akshat Tomar" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/akshat">Akshat Tomar</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y25/arnav.png" alt="Arnav Bendre" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/arnav">Arnav Bendre</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y25/gaurav.jpg" alt="Gaurav Kumar" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/gaurav">Gaurav Kumar</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y25/laabhanvi.jpg" alt="Laabhanvi Jain" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/laabhanvi">Laabhanvi Jain</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y25/manjot.jpg" alt="Manjot Singh" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/manjot">Manjot Singh</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y25/raj.jpg" alt="Raj Shekhar Singh" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/raj">Raj Shekhar Singh</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y25/shreyansh.jpg" alt="Shreyansh Modi" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/shreyansh">Shreyansh Modi</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y25/srijan.jpg" alt="Srijan Tiwari" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/srijan">Srijan Tiwari</a></h3>
+      </div>
+    </div>
+  </div>
+
+  <!-- 1st Year (Y26) -->
+  <div class="year-section">
+    <h2 class="year-header">1st Year (Y26)</h2>
+    <div class="member-grid">
+      <!-- Add Y26 members here. Example:
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y26/example.jpg" alt="Member Name" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/examplename">Member Name</a></h3>
+      </div>
+      -->
+    </div>
+  </div>
+
+  <!-- Alumni (Y22 & Earlier) -->
+  <div class="year-section">
+    <h2 class="year-header">Alumni</h2>
+    <div class="member-grid">
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y22/aasthakhaitan.jpeg" alt="Aastha Khaitan" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/aasthakhaitan">Aastha Khaitan (Y22)</a></h3>
+      </div>
+      <div class="member-card">
+        <img src="{{ site.baseurl }}/assets/images/members/y22/vedumrajkar.jpeg" alt="Ved Umrajkar" onerror="this.src='{{ site.baseurl }}/assets/images/placeholder.jpeg';">
+        <h3><a href="{{ site.baseurl }}/members/vedumrajkar">Ved Umrajkar (Y22)</a></h3>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -59,11 +59,11 @@ permalink: /projects/
   font-size: 1rem;
   color: #5a6c7d;
   line-height: 1.6;
-  flex-grow: 1; /* Pushes links to bottom */
+  flex-grow: 1; /* Pushes links to the bottom */
   margin-bottom: 24px;
 }
 
-/* Links Container */
+/* Links & Buttons Container */
 .project-links {
   display: flex;
   gap: 12px;
@@ -81,6 +81,7 @@ permalink: /projects/
   transition: all 0.2s ease;
 }
 
+/* Primary Button (Details) */
 .project-links .btn-details {
   background: #007acc;
   color: white;
@@ -90,6 +91,7 @@ permalink: /projects/
   background: #005ea6;
 }
 
+/* Secondary Button (GitHub) */
 .project-links .btn-github {
   background: #24292e;
   color: white;
@@ -110,13 +112,37 @@ permalink: /projects/
 <div class="project-grid">
 
   <div class="project-card">
-    <img src="{{ site.baseurl }}/assets/images/projects/DL_Playground.png" alt="DL-PLayground">
+    <img src="{{ site.baseurl }}/assets/images/projects/DL_Playground.png" alt="DL-Playground">
     <div class="project-card-content">
       <h3>DL-Playground</h3>
-      <p>DL-Playground is an interactive, web-based visual editor for designing, prototyping, and understanding PyTorch neural network architectures.</p>
+      <p>Interactive, web-based visual editor for designing, prototyping, and understanding PyTorch neural network architectures with drag-and-drop interface.</p>
       <div class="project-links">
         <a href="https://github.com/dsgiitr/DL-Playground" target="_blank" class="btn-github">GitHub</a>
         <a href="{{ site.baseurl }}/projects/DL_playground/" class="btn-details">Details</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="project-card">
+    <img src="{{ site.baseurl }}/assets/images/d2l_pytorch.svg" alt="d2l PyTorch">
+    <div class="project-card-content">
+      <h3>d2l-pytorch</h3>
+      <p>Full reproduction of the acclaimed book Dive Into Deep Learning (www.d2l.ai), adapting the code from MXNet into PyTorch.</p>
+      <div class="project-links">
+        <a href="https://github.com/dsgiitr/d2l-pytorch" target="_blank" class="btn-github">GitHub</a>
+        <a href="{{ site.baseurl }}/projects/d2l-pytorch/" class="btn-details">Details</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="project-card">
+    <img src="{{ site.baseurl }}/assets/images/visualml.png" alt="Visual ML">
+    <div class="project-card-content">
+      <h3>Visual ML</h3>
+      <p>Interactive Visual Machine Learning Demos directly in your browser. Live machine learning training and inference powered by TF JS.</p>
+      <div class="project-links">
+        <a href="https://github.com/dsgiitr/VisualML" target="_blank" class="btn-github">GitHub</a>
+        <a href="{{ site.baseurl }}/projects/visual_ml/" class="btn-details">Details</a>
       </div>
     </div>
   </div>
@@ -133,11 +159,24 @@ permalink: /projects/
     </div>
   </div>
 
+    <div class="project-card">
+    <img src="{{ site.baseurl }}/assets/images/projects/kge.png" alt="KGE">
+    <div class="project-card-content">
+      <h3>Knowledge Graph Embeddings for VLMs</h3>
+      <p>Analyzing the impact of vector and graph embeddings on retrieval generation of Vision-Language Models on downstream tasks.</p>
+      <div class="project-links">
+        <a href="https://github.com/dsgiitr/kge-clip" target="_blank" class="btn-github">GitHub</a>
+        <a href="https://agam-pandey.gitbook.io/knowledge-graph-embedding-or-dsg-iitr/" class="btn-details">Details</a>
+      </div>
+    </div>
+
+  </div>
+
   <div class="project-card">
     <img src="{{ site.baseurl }}/assets/images/diffusion-everything/banner.png" alt="Diffusion-Everything">
     <div class="project-card-content">
       <h3>Diffusion Everything</h3>
-      <p>Demos involving diffusion models: Training & inference of diffusion on a custom 2D dataset, VAE and latent diffusion models, and more.</p>
+      <p>Comprehensive resource and visualizations of diffusion models: Training, inference, VAE and latent diffusion models with live demos.</p>
       <div class="project-links">
         <a href="https://github.com/dsgiitr/diffusion-everything" target="_blank" class="btn-github">GitHub</a>
         <a href="{{ site.baseurl }}/projects/diffusion-everything/" class="btn-details">Details</a>   
@@ -161,7 +200,7 @@ permalink: /projects/
     <img src="{{ site.baseurl }}/assets/images/research/ImageAlchemy.png" alt="ImageAlchemy">
     <div class="project-card-content">
       <h3>Image-Alchemy</h3>
-      <p>A two-stage personalization pipeline for customized image generation using LoRA-based attention fine-tuning and guided Img2Img synthesis.</p>
+      <p>Two-stage personalization pipeline for customized image generation using LoRA-based attention fine-tuning and guided Img2Img synthesis.</p>
       <div class="project-links">
         <a href="https://github.com/kaustubh202/image-alchemy" target="_blank" class="btn-github">GitHub</a>
         <a href="{{ site.baseurl }}/projects/image_alchemy/" class="btn-details">Details</a>
@@ -170,22 +209,10 @@ permalink: /projects/
   </div>
 
   <div class="project-card">
-    <img src="{{ site.baseurl }}/assets/images/projects/kge.png" alt="KGE">     
-    <div class="project-card-content">
-      <h3>Knowledge Graph Embeddings for VLMs</h3>
-      <p>Analyzing the impact of vector and graph embeddings on retrieval generation of VLMs on downstream tasks.</p>
-      <div class="project-links">
-        <a href="https://github.com/dsgiitr/kge-clip" target="_blank" class="btn-github">GitHub</a>  
-        <a href="https://agam-pandey.gitbook.io/knowledge-graph-embedding-or-dsg-iitr/" class="btn-details">Details</a>
-      </div>
-    </div>
-  </div>
-
-  <div class="project-card">
     <img src="{{ site.baseurl }}/assets/images/projects/feedcode.png" alt="FeedCode">
     <div class="project-card-content">
       <h3>FeedCode</h3>
-      <p>FeedCode is an intelligent LLM feedback tool that provides personalized code reviews based on your coding style and activity.</p>
+      <p>Intelligent LLM feedback tool that provides personalized code reviews based on your coding style and GitHub activity.</p>
       <div class="project-links">
         <a href="https://github.com/AbhishekPanwarr/feedCode" target="_blank" class="btn-github">GitHub</a>
         <a href="{{ site.baseurl }}/projects/visual_ml/" class="btn-details">Details</a>
@@ -194,26 +221,123 @@ permalink: /projects/
   </div>
 
   <div class="project-card">
-    <img src="{{ site.baseurl }}/assets/images/visualml.png" alt="Visual Ml">   
+    <img src="{{ site.baseurl }}/assets/images/adversarial_example.gif" alt="Adversarial Lab">
     <div class="project-card-content">
-      <h3>Visual ML</h3>
-      <p>Interactive Visual Machine Learning Demos directly in your browser. Live machine learning training and inference powered by TF JS.</p>
+      <h3>Adversarial Lab</h3>
+      <p>Web-based tool for visualization and generation of adversarial examples by attacking ImageNet models like VGG, AlexNet, and ResNet.</p>
       <div class="project-links">
-        <a href="https://github.com/dsgiitr/VisualML" target="_blank" class="btn-github">GitHub</a>  
-        <a href="{{ site.baseurl }}/projects/visual_ml/" class="btn-details">Details</a>
+        <a href="https://github.com/dsgiitr/adversarial_lab" target="_blank" class="btn-github">GitHub</a>
+        <a href="{{ site.baseurl }}/projects/adversarial_lab/" class="btn-details">Details</a>
       </div>
     </div>
   </div>
 
   <div class="project-card">
-    <img src="{{ site.baseurl }}/assets/images/d2l_pytorch.svg" alt="d2l PyTorch">
+    <img src="{{ site.baseurl }}/assets/images/Eye_In_The_Sky.svg" alt="Eye in the Sky">
     <div class="project-card-content">
-      <h3>d2l-pytorch</h3>
-      <p>This project fully reproduces the highly acclaimed book Dive Into Deep Learning (www.d2l.ai), adapting the code from MXNet into PyTorch.</p>
+      <h3>Eye in the Sky</h3>
+      <p>Winning solution for Inter IIT Tech Meet 2018 satellite image segmentation challenge. Semantic segmentation of remote sensing data.</p>
       <div class="project-links">
-        <a href="https://github.com/dsgiitr/d2l-pytorch" target="_blank" class="btn-github">GitHub</a>
-        <a href="{{ site.baseurl }}/projects/d2l-pytorch/" class="btn-details">Details</a>
+        <a href="https://github.com/dsgiitr/eye_in_the_sky" target="_blank" class="btn-github">GitHub</a>
+        <a href="{{ site.baseurl }}/projects/eye_in_the_sky/" class="btn-details">Details</a>
       </div>
     </div>
   </div>
+
+  <div class="project-card">
+    <img src="{{ site.baseurl }}/assets/images/generative.jpg" alt="Fortnite AI">
+    <div class="project-card-content">
+      <h3>Fortnite AI Agent</h3>
+      <p>AI agent capable of playing Fortnite using DreamerV3 reinforcement learning with real-time screen capture and input simulation.</p>
+      <div class="project-links">
+        <a href="https://github.com/dsgiitr/FORT-N-AI" target="_blank" class="btn-github">GitHub</a>
+        <a href="{{ site.baseurl }}/projects/fort-n-ai/" class="btn-details">Details</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="project-card">
+    <img src="{{ site.baseurl }}/assets/images/graph_nets.svg" alt="Graph Nets">
+    <div class="project-card-content">
+      <h3>Graph Representation Learning</h3>
+      <p>Simplified yet exhaustive implementation and explanation of various graph representation learning techniques (DeepWalk, GCN, GraphSAGE, GAT).</p>
+      <div class="project-links">
+        <a href="https://github.com/dsgiitr/graph_nets" target="_blank" class="btn-github">GitHub</a>
+        <a href="{{ site.baseurl }}/projects/graph_nets/" class="btn-details">Details</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="project-card">
+    <img src="{{ site.baseurl }}/assets/images/neural_style.gif" alt="Neural Style Transfer">
+    <div class="project-card-content">
+      <h3>Neural Style Transfer</h3>
+      <p>Keras implementation of neural style transfer that generates images with content from one image and style from another using deep learning.</p>
+      <div class="project-links">
+        <a href="https://github.com/dsgiitr/neural_style_transfer" target="_blank" class="btn-github">GitHub</a>
+        <a href="{{ site.baseurl }}/projects/neural_style/" class="btn-details">Details</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="project-card">
+    <img src="{{ site.baseurl }}/assets/images/np_detection.gif" alt="Number Plate Detection">
+    <div class="project-card-content">
+      <h3>Number Plate Detection</h3>
+      <p>System for detecting and recognizing vehicle number plates using YOLO object detection and OCR techniques for security purposes.</p>
+      <div class="project-links">
+        <a href="https://github.com/dsgiitr/np_detection" target="_blank" class="btn-github">GitHub</a>
+        <a href="{{ site.baseurl }}/projects/np_detection/" class="btn-details">Details</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="project-card">
+    <img src="{{ site.baseurl }}/assets/images/rl2048.jpeg" alt="RL 2048">
+    <div class="project-card-content">
+      <h3>Reinforcement Learning 2048</h3>
+      <p>Implementation of Deep Q-Network using Double Q-Learning to autonomously play the 2048 game and learn optimal strategies.</p>
+      <div class="project-links">
+        <a href="https://github.com/dsgiitr/RL2048" target="_blank" class="btn-github">GitHub</a>
+        <a href="{{ site.baseurl }}/projects/rl2048/" class="btn-details">Details</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="project-card">
+    <img src="{{ site.baseurl }}/assets/images/generative.jpg" alt="Sarcasm Detection">
+    <div class="project-card-content">
+      <h3>Sarcasm Detection using BERT</h3>
+      <p>NLP project exploring contextual sarcasm detection using BERT and LSTM models on news headlines dataset for sentiment understanding.</p>
+      <div class="project-links">
+        <a href="https://github.com/dsgiitr/sarcasm-detection" target="_blank" class="btn-github">GitHub</a>
+        <a href="{{ site.baseurl }}/projects/sarcasm_detection/" class="btn-details">Details</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="project-card">
+    <img src="{{ site.baseurl }}/assets/images/Traffic_sign.jpg" alt="Traffic Sign Classification">
+    <div class="project-card-content">
+      <h3>Traffic Sign Classification</h3>
+      <p>Beginner-friendly computer vision project recognizing 43 different traffic signs from the GTSRB dataset for autonomous vehicle applications.</p>
+      <div class="project-links">
+        <a href="https://github.com/dsgiitr/traffic_sign_classification" target="_blank" class="btn-github">GitHub</a>
+        <a href="{{ site.baseurl }}/projects/traffic_sign_classification/" class="btn-details">Details</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="project-card">
+    <img src="{{ site.baseurl }}/assets/images/visualizing_loss.jpg" alt="Visualizing Loss">
+    <div class="project-card-content">
+      <h3>Visualizing Loss Functions</h3>
+      <p>Visualization of different loss and optimization functions using Autoencoders on MNIST to understand their impact on training.</p>
+      <div class="project-links">
+        <a href="https://github.com/dsgiitr/visualizing_loss" target="_blank" class="btn-github">GitHub</a>
+        <a href="{{ site.baseurl }}/projects/visualizing_loss/" class="btn-details">Details</a>
+      </div>
+    </div>
+  </div>
+
 </div>


### PR DESCRIPTION

- Update projects.md with all 19 projects in responsive grid layout
  * Reorder projects: DL-Playground, d2l-pytorch, Visual ML first
  * Add descriptions and GitHub/Details links for all projects
- Reorganize about.md team section by current year groups
  * Y23 as 4th Year, Y24 as 3rd Year, Y25 as 2nd Year, Y26 as 1st Year
  * Sort members alphabetically within each year section
  * Create separate Alumni section for past members (Y22)
  * Add placeholder for incoming Y26 batch
- Improve visual design with smooth hover effects and modern card styling
- Add image fallback handling for missing member photos